### PR TITLE
dynamic tether: add jinja generation capability

### DIFF
--- a/models/solo_with_tether/solo_with_tether.sdf
+++ b/models/solo_with_tether/solo_with_tether.sdf
@@ -7,7 +7,7 @@
       <uri>model://tether</uri>
       <pose>-0.12 0 0 0 3.1415 0</pose>
     </include>
-    <joint name="tether_joint" type="universal">
+    <joint name="tether_joint" type="revolute">
       <child>solo::base_link</child>
       <parent>tether::link_00</parent>
       <axis>
@@ -43,6 +43,14 @@
 	  <cfm_damping>1</cfm_damping>
 	</ode>
       </physics>
+      <sensor name="tether_force_torque" type="force_torque">
+	<always_on>true</always_on>
+	<update_rate>100</update_rate>
+	<force_torque>
+	  <frame>child</frame>
+	  <measure_direction>child_to_parent</measure_direction>
+	</force_torque>
+      </sensor>
     </joint>
   </model>
 </sdf>

--- a/models/solo_with_tether/solo_with_tether.sdf
+++ b/models/solo_with_tether/solo_with_tether.sdf
@@ -9,13 +9,9 @@
     </include>
     <joint name="tether_joint" type="revolute">
       <child>solo::base_link</child>
-      <parent>tether::link_00</parent>
+      <parent>tether::link_0</parent>
       <axis>
 	<xyz>0 1 0</xyz>
-	<limit>
-	  <lower>-1.57</lower>
-	  <upper>1.57</upper>
-	</limit>
 	<dynamics>
           <damping>0.1</damping>
           <friction>0.0</friction>
@@ -26,10 +22,6 @@
       </axis>
       <axis2>
 	<xyz>0 0 1</xyz>
-	<limit>
-	  <lower>-1.57</lower>
-	  <upper>1.57</upper>
-	</limit>
 	<dynamics>
           <damping>0.1</damping>
           <friction>0.0</friction>

--- a/models/tether/model.config
+++ b/models/tether/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>tether</name>
   <version>1.0.0</version>
-  <sdf version='1.5'>model.sdf</sdf>
+  <sdf version='1.5'>tether-gen.sdf</sdf>
   <author>
     <name>Nuno Marques</name>
     <email>n.marques21@hotmail.com</email>

--- a/models/tether/model.sdf
+++ b/models/tether/model.sdf
@@ -1,4 +1,5 @@
 <?xml version="1.0" ?>
+<!-- This model was built manually. Use the jinja generated one instead. -->
 <sdf version="1.5">
   <model name="tether">
     <pose>-1.81 -4.23 0.055 0 0 0</pose>

--- a/models/tether/tether.sdf.jinja
+++ b/models/tether/tether.sdf.jinja
@@ -1,0 +1,193 @@
+{#-------------------SDF generator for Tether Gazebo model--------------------#}
+{#--------------The parameters bellow are the ones to be tweaked--------------#}
+{#--------------------------:Tweakable parameters:----------------------------#}
+{%- set number_elements = 20 -%}
+{%- set last_elem = number_elements |int - 1 -%}
+{%- set m = 0.03 -%}			{#- m: mass of the element -#}
+{%- set cl = 0.2 -%}			{#- cl: length of the element -#}
+{%- set cr = 0.001 -%}			{#- cr: radius of the element -#}
+{%- set sr = 0.009 -%}			{#- sr: element joint radius (sphere)-#}
+{%- set damping = 0.05 -%}
+{%- set friction = 0.0 -%}
+{%- set spring_stiffness = 0.05 -%}
+{%- set spring_reference = 0.0 -%}
+{%- set element_color = 'White' -%}
+{%- set joint_color = 'Red' -%}
+{#----------------------------------------------------------------------------#}
+
+{%- macro cylinder(cl, cr) -%}
+      <geometry>
+          <cylinder>
+            <length>{{cl}}</length>
+            <radius>{{cr}}</radius>
+          </cylinder>
+        </geometry>
+{%- endmacro -%}
+
+{%- macro sphere(sr) -%}
+      <geometry>
+          <sphere>
+            <radius>{{sr}}</radius>
+          </sphere>
+        </geometry>
+{%- endmacro -%}
+
+{%- macro inertial(m) -%}
+{#- A note about the inertial tensor matrix - It should be as bellow -#}
+{#- {%- set izz = m/2*cr**2 -%} -#}
+{#- {%- set ixx = m/12*cl**2 + m/4*cr**2 -%} -#}
+{#- {%- set iyy = m/12*cl**2 + m/4*cr**2 -%} -#}
+{#- but seems to segfault Gazebo when changing the values of the element specs -#}
+{%- set izz = 0.01 -%}
+{%- set ixx = 0.01 -%}
+{%- set iyy = 0.01 -%}
+      <inertial>
+        <mass>{{m}}</mass>
+        <inertia>
+          <ixx>{{ixx}}</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>{{iyy}}</iyy>
+          <iyz>0</iyz>
+          <izz>{{izz}}</izz>
+        </inertia>
+      </inertial>
+{%- endmacro -%}
+
+{%- macro collision(cl, cr) -%}
+<collision name="collision">
+        <pose>0.1 0 0 0 1.570790 0</pose>
+        {{ cylinder(cl, cr) }}
+        <surface>
+          <contact>
+            <ode>
+	      <min_depth>0.00005</min_depth>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+	      <mu>1.0</mu>
+	      <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+{%- endmacro -%}
+
+{%- macro element_material(element_color) -%}
+      <material>
+        <script>
+          <name>Gazebo/{{element_color}}</name>
+          <uri>file://media/materials/scripts/gazebo.material</uri>
+        </script>
+      </material>
+{%- endmacro -%}
+
+{%- macro joint_material(joint_color) -%}
+      <material>
+        <script>
+          <name>Gazebo/{{joint_color}}</name>
+          <uri>file://media/materials/scripts/gazebo.material</uri>
+        </script>
+      </material>
+{%- endmacro -%}
+
+{%- macro element_visual(cl, cr, element_color) -%}
+{%- set x = cl * 0.5 -%}
+      <visual name="element_visual">
+        <pose>{{x}} 0 0 0 1.570790 0</pose>
+        {{ cylinder(cl, cr) }}
+        {{ element_material(element_color) }}
+      </visual>
+{%- endmacro -%}
+
+{%- macro sphere_visual(sr, sphere_clor) -%}
+      <visual name="sphere_visual">
+        {{ sphere(sr) }}
+        {{ joint_material(joint_color) }}
+      </visual>
+{%- endmacro -%}
+
+{%- macro link(n, m, cl, cr, sr, element_color, joint_color) -%}
+{%- set x = n * cl / 2 + ( n - 1) * cl / 2 -%}
+{%- set y = 0.0 -%}
+{%- set z = 0.0 -%}
+<link name="link_{{n}}">
+      <gravity>true</gravity>
+      <pose>{{x}} {{y}} {{z}} 0.0 0.0 0.0</pose>
+      {{ inertial(m) }}
+      {{ collision(cl, cr) }}
+      {{ element_visual(cl, cr, element_color) }}
+      {{ sphere_visual(sr, joint_color) }}
+    </link>
+{%- endmacro -%}
+
+{%- macro joint(k, damping, friction, spring_stiffness, spring_reference) -%}
+{%- set link_n = k - 1 -%}
+<joint name="joint_{{k}}" type="universal">
+      <child>link_{{k}}</child>
+      <parent>link_{{link_n}}</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <dynamics>
+          <damping>{{damping}}</damping>
+          <friction>{{friction}}</friction>
+          <spring_stiffness>{{spring_stiffness}}</spring_stiffness>
+          <spring_reference>{{spring_reference}}</spring_reference>
+        </dynamics>
+        <use_parent_model_frame>true</use_parent_model_frame>
+      </axis>
+      <axis2>
+        <xyz>0 0 1</xyz>
+        <dynamics>
+          <damping>{{damping}}</damping>
+          <friction>{{friction}}</friction>
+          <spring_stiffness>{{spring_stiffness}}</spring_stiffness>
+          <spring_reference>{{spring_reference}}</spring_reference>
+        </dynamics>
+        <use_parent_model_frame>true</use_parent_model_frame>
+      </axis2>
+      <physics>
+        <ode>
+          <cfm_damping>1</cfm_damping>
+        </ode>
+      </physics>
+    </joint>
+{%- endmacro -%}
+
+{%- macro lift_drag(n, cl, cr) -%}
+{%- set area = 2*3.14159265358*cr*cl -%}
+<plugin name="link{{n}}_drag" filename="libLiftDragPlugin.so">
+      <robotNamespace></robotNamespace>
+      <a0>0</a0>
+      <cla>0</cla>
+      <cda>1.2535816618911175</cda>
+      <alpha_stall>0</alpha_stall>
+      <cda_stall>1.4326647564469914</cda_stall>
+      <cp>0 0 0</cp>
+      <area>{{area}}</area>
+      <air_density>1.2041</air_density>
+      <forward>0 1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>link_{{n}}</link_name>
+    </plugin>
+{%- endmacro -%}
+
+<?xml version="1.0" ?>
+<!-- DO NOT EDIT: Generated from tether.sdf.jinja -->
+<sdf version="1.5">
+  <model name="tether">
+    <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+    {% for n in range(number_elements) -%}
+    {{ link(n, m, cl, cr, sr, element_color, joint_color) }}
+    {{ lift_drag(n, cl, cr) }}
+    {% endfor -%}
+    {% for k in range(1, number_elements) -%}
+    {{ joint(k, damping, friction, spring_stiffness, spring_reference) }}
+    {% endfor -%}
+    <joint name="fixed_to_world" type="fixed">
+      <child>link_{{last_elem}}</child>
+      <parent>world</parent>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
This PR adds two things:
1. 1a185b3 adds the force/torque sensor on the tether joint (0), the one attached to the copter;
2. 455b449 allows to easily create the tether the user wants with several tweakable parameters, starting on the number of elements, etc. It generates a `tether-gen.sdf`, which is then loaded into the Gazebo world.

To check the generated SDF model, just build the repo and `tether-gen.sdf` will be generated. The output can be checked [here](https://pastebin.com/HU4U6kse).